### PR TITLE
.gitignore: auto_splitter_logs.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+auto_splitter_logs.txt


### PR DESCRIPTION
Adds `auto_splitter_logs.txt` to the `.gitignore` so that git doesn't try to track it when I press the `Save` button on the logs.