### PR TITLE
ComboBox width

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -574,7 +574,11 @@ impl egui_dock::TabViewer for TabViewer<'_> {
                                     label.on_hover_text(&**tooltip);
                                 }
 
-                                let combo_box = ComboBox::new(&setting.key, "");
+                                let mut opt_desc_lens: Vec<usize> = options.iter().map(|o| o.description.len()).collect();
+                                opt_desc_lens.sort();
+                                let width = 0.55 * 1.25 * 14.0 * (opt_desc_lens[(opt_desc_lens.len() * 7) / 8] as f32);
+
+                                let combo_box = ComboBox::new(&setting.key, "").width(width);
 
                                 let settings_map = runtime.settings_map();
 


### PR DESCRIPTION
Sets the `ComboBox` width to be approximately the width of the 7/8ths-percentile  option description. The goal is to have at least 7 out of every 8 option descriptions not have to be line-wrapped on average.

I think this goes by bytes, not by chars or grapheme clusters, and certainly not by precise rendered width of anything, but if that kind of unicode weirdness only affects less than 1/8th of the option descriptions, I hope this is a good enough approximation.