### PR TITLE
Add FileSelection Widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
  "once_cell",
  "paste",
  "static_assertions",
- "windows",
+ "windows 0.48.0",
 ]
 
 [[package]]
@@ -165,9 +165,9 @@ checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
 
 [[package]]
 name = "arbitrary"
@@ -217,6 +217,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "atomic",
+ "bstr",
  "byte-unit",
  "clap",
  "eframe",
@@ -226,6 +227,7 @@ dependencies = [
  "hdrhistogram",
  "indexmap",
  "livesplit-auto-splitting",
+ "mime_guess",
 ]
 
 [[package]]
@@ -245,7 +247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
 dependencies = [
  "concurrent-queue",
- "event-listener 4.0.0",
+ "event-listener 4.0.1",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -331,7 +333,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7125e42787d53db9dd54261812ef17e937c95a51e4d291373b670342fa44310c"
 dependencies = [
- "event-listener 4.0.0",
+ "event-listener 4.0.1",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -367,7 +369,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -396,13 +398,13 @@ checksum = "e1d90cd0b264dfdd8eb5bad0a2c217c1f88fa96a8573f40e7b12de23fb468f46"
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "fdf6721fb0140e4f897002dd086c06f6c27775df19cfe1fccb21181a48fd2c98"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -500,7 +502,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -579,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9897ef0f1bd2362169de6d7e436ea2237dc1085d7d1e4db75f4be34d86f309d1"
+checksum = "26d4d6dafc1a3bb54687538972158f07b2c948bc57d5890df22c0739098b3028"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -589,16 +591,27 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478b41ff04256c5c8330f3dfdaaae2a5cc976a8e75088bafa4625b0d0208de8c"
+checksum = "bf4918709cc4dd777ad2b6303ed03cb37f3ca0ccede8c1b0d28ac6db8f4710e0"
 dependencies = [
  "once_cell",
  "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
  "syn_derive",
+]
+
+[[package]]
+name = "bstr"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -657,7 +670,7 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -835,7 +848,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -961,18 +974,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.102.1"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7e56668d2263f92b691cb9e4a2fcb186ca0384941fe420484322fa559c3329"
+checksum = "7c22542c0b95bd3302f7ed6839869c561f2324bac2fd5e7e99f5cfa65fdc8b92"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.102.1"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a9ff61938bf11615f55b80361288c68865318025632ea73c65c0b44fa16283c"
+checksum = "6b3db903ef2e9c8a4de2ea6db5db052c7857282952f9df604aa55d169e6000d8"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -991,33 +1004,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.102.1"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50656bf19e3d4a153b404ff835b8b59e924cfa3682ebe0d3df408994f37983f6"
+checksum = "6590feb5a1d6438f974bf6a5ac4dddf69fca14e1f07f3265d880f69e61a94463"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.102.1"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388041deeb26109f1ea73c1812ea26bfd406c94cbce0bb5230aa44277e43b209"
+checksum = "7239038c56fafe77fddc8788fc8533dd6c474dc5bdc5637216404f41ba807330"
 
 [[package]]
 name = "cranelift-control"
-version = "0.102.1"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39b7c512ffac527e5b5df9beae3d67ab85d07dca6d88942c16195439fedd1d3"
+checksum = "f7dc9c595341404d381d27a3d950160856b35b402275f0c3990cd1ad683c8053"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.102.1"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb25f573701284fe2bcf88209d405342125df00764b396c923e11eafc94d892"
+checksum = "44e3ee532fc4776c69bcedf7e62f9632cbb3f35776fa9a525cdade3195baa3f7"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1025,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.102.1"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57374fd11d72cf9ffb85ff64506ed831440818318f58d09f45b4185e5e9c376"
+checksum = "a612c94d09e653662ec37681dc2d6fd2b9856e6df7147be0afc9aabb0abf19df"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1037,15 +1050,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.102.1"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae769b235f6ea2f86623a3ff157cc04a4ff131dc9fe782c2ebd35f272043581e"
+checksum = "85db9830abeb1170b7d29b536ffd55af1d4d26ac8a77570b5d1aca003bf225cc"
 
 [[package]]
 name = "cranelift-native"
-version = "0.102.1"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc7bfb8f13a0526fe20db338711d9354729b861c336978380bb10f7f17dd207"
+checksum = "301ef0edafeaeda5771a5d2db64ac53e1818ae3111220a185677025fe91db4a1"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1054,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.102.1"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5f41a4af931b756be05af0dd374ce200aae2d52cea16b0beb07e8b52732c35"
+checksum = "380f0abe8264e4570ac615fc31cef32a3b90a77f7eb97b08331f9dd357b1f500"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1352,7 +1365,7 @@ checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -1416,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770d968249b5d99410d61f5bf89057f3199a077a04d087092f58e7d10692baae"
+checksum = "84f2cdcf274580f2d63697192d744727b3198894b1bf02923643bf59e2c26712"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1431,7 +1444,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
- "event-listener 4.0.0",
+ "event-listener 4.0.1",
  "pin-project-lite",
 ]
 
@@ -2027,7 +2040,7 @@ checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 [[package]]
 name = "livesplit-auto-splitting"
 version = "0.1.0"
-source = "git+https://github.com/LiveSplit/livesplit-core#754799c06b2a34f26f48a33be55b1e2a17e8f2e6"
+source = "git+https://github.com/LiveSplit/livesplit-core#d9ec8570f3f196117edeb016a81443bad7543c97"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2073,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "mach2"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
 ]
@@ -2144,6 +2157,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -2334,7 +2363,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -2510,9 +2539,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "png"
@@ -2975,7 +3004,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -2997,7 +3026,7 @@ checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -3181,9 +3210,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3199,14 +3228,14 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
 name = "sysinfo"
-version = "0.29.11"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
+checksum = "c68492e7268037de59ae153d7efb79546cf94a18a9548235420d3d8d2436b4b1"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -3214,7 +3243,7 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "winapi",
+ "windows 0.51.1",
 ]
 
 [[package]]
@@ -3275,14 +3304,14 @@ checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
  "deranged",
  "powerfmt",
@@ -3383,7 +3412,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -3416,6 +3445,15 @@ dependencies = [
  "memoffset 0.9.0",
  "tempfile",
  "winapi",
+]
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -3498,9 +3536,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4328de5cf2a0debfc48216fe9c2747badc64957837641f5836cd8b3d48d73f0"
+checksum = "154528979a211aa28d969846e883df75705809ed9bcc70aba61460683ea7355b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3521,9 +3559,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f6774ec9e464b7373f683bc57ff87fcca5fd26a7d6bdb7438fb2f56a545aa6"
+checksum = "3d888b611fee7d273dd057dc009d2dd3132736f36710ffd65657ac83628d1e3b"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -3560,7 +3598,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
  "wasm-bindgen-shared",
 ]
 
@@ -3594,7 +3632,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3607,18 +3645,18 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.36.2"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822b645bf4f2446b949776ffca47e2af60b167209ffb70814ef8779d299cd421"
+checksum = "0ad2b51884de9c7f4fe2fd1043fccb8dcad4b1e29558146ee57a144d15779f3f"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.116.1"
+version = "0.118.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
+checksum = "95ee9723b928e735d53000dec9eae7b07a60e490c85ab54abb66659fc61bfcd9"
 dependencies = [
  "indexmap",
  "semver",
@@ -3626,9 +3664,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642e12d108e800215263e3b95972977f473957923103029d7d617db701d67ba4"
+checksum = "a8e539fded2495422ea3c4dfa7beeddba45904eece182cf315294009e1a323bf"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3640,7 +3678,6 @@ dependencies = [
  "object",
  "once_cell",
  "paste",
- "psm",
  "rayon",
  "serde",
  "serde_derive",
@@ -3656,18 +3693,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beada8bb15df52503de0a4c58de4357bfd2f96d9a44a6e547bad11efdd988b47"
+checksum = "660ba9143e15a2acd921820df221b73aee256bd3ca2d208d73d8adc9587ccbb9"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2e7532f1d6adbcc57e69bb6a7c503f0859076d07a9b4b6aabe8021ff8a05fd"
+checksum = "2d648c8b4064a7911093b02237cd5569f71ca171d3a0a486bf80600b19e1cba2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3690,9 +3727,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c98d5378a856cbf058d36278627dfabf0ed68a888142958c7ae8e6af507dafa"
+checksum = "290a89027688782da8ff60b12bb95695494b1874e0d0ba2ba387d23dace6d70c"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3706,9 +3743,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d33a9f421da810a070cd56add9bc51f852bd66afbb8b920489d6242f15b70e"
+checksum = "61eb64fb3e0da883e2df4a13a81d6282e072336e6cb6295021d0f7ab2e352754"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -3726,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d0994a86d6dca5f7d9740d7f2bd0568be06d2014a550361dc1c397d289d81ef"
+checksum = "f485336add49267d8859e8f8084d2d4b9a4b1564496b6f30ba5b168d50c10ceb"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3747,20 +3784,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-jit-debug"
-version = "15.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0c4b74e606d1462d648631d5bc328e3d5b14e7f9d3ff93bc6db062fb8c5cd8"
-dependencies = [
- "once_cell",
- "wasmtime-versioned-export-macros",
-]
-
-[[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3090a69ba1476979e090aa7ed4bc759178bafdb65b22f98b9ba24fc6e7e578d5"
+checksum = "6b6d197fcc34ad32ed440e1f9552fd57d1f377d9699d31dee1b5b457322c1f8a"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3769,9 +3796,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b993ac8380385ed67bf71b51b9553edcf1ab0801b78a805a067de581b9a3e88a"
+checksum = "794b2bb19b99ef8322ff0dd9fe1ba7e19c41036dfb260b3f99ecce128c42ff92"
 dependencies = [
  "anyhow",
  "cc",
@@ -3783,13 +3810,12 @@ dependencies = [
  "memfd",
  "memoffset 0.9.0",
  "paste",
- "rand",
+ "psm",
  "rustix 0.38.28",
  "sptr",
  "wasm-encoder",
  "wasmtime-asm-macros",
  "wasmtime-environ",
- "wasmtime-jit-debug",
  "wasmtime-versioned-export-macros",
  "wasmtime-wmemcheck",
  "windows-sys 0.48.0",
@@ -3797,9 +3823,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5778112fcab2dc3d4371f4203ab8facf0c453dd94312b0a88dd662955e64e0"
+checksum = "d995db8bb56f2cd8d2dc0ed5ffab94ffb435283b0fe6747f80f7aab40b2d06a1"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3810,20 +3836,20 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50f51f8d79bfd2aa8e9d9a0ae7c2d02b45fe412e62ff1b87c0c81b07c738231"
+checksum = "f55c5565959287c21dd0f4277ae3518dd2ae62679f655ee2dbc4396e19d210db"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff3f4ad191a5e6d002bb5bffa3e2931a58984da9b30e57b48f353848748cf80"
+checksum = "ccd8370078149d49a3a47e93741553fd79b700421464b6a27ca32718192ab130"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3841,9 +3867,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6060bc082cc32d9a45587c7640e29e3c7b89ada82677ac25d87850aaccb368"
+checksum = "67761d8f8c0b3c13a5d34356274b10a40baba67fe9cfabbfc379a8b414e45de2"
 
 [[package]]
 name = "wast"
@@ -3978,9 +4004,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91028b241e692fdf30627ac10ba9d5ac378353ea4119b4f904ac95177057a44"
+checksum = "0afb26cd3269289bb314a361ff0a6685e5ce793b62181a9fe3f81ace15051697"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3993,28 +4019,28 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8b3d76531994513671b2ec3b29fd342bf041e2282945bb6c52eebe6aa9e7da"
+checksum = "cef2868fed7584d2b552fa317104858ded80021d23b073b2d682d3c932a027bd"
 dependencies = [
  "anyhow",
  "heck",
  "proc-macro2",
  "quote",
  "shellexpand",
- "syn 2.0.41",
+ "syn 2.0.42",
  "witx",
 ]
 
 [[package]]
 name = "wiggle-macro"
-version = "15.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c189fe00c67f61bb330827f2abab1af9b5925c7929535cd13a68d265ec20b02d"
+checksum = "31ae1ec11a17ea481539ee9a5719a278c9790d974060fbf71db4b2c05378780b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
  "wiggle-generate",
 ]
 
@@ -4066,6 +4092,25 @@ checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
  "windows-implement",
  "windows-interface",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
  "windows-targets 0.48.5",
 ]
 
@@ -4326,9 +4371,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.5.28"
+version = "0.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
+checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
 dependencies = [
  "memchr",
 ]
@@ -4502,7 +4547,7 @@ checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atomic = "0.6.0"
 anyhow = "1.0.75"
 arc-swap = "1.6.0"
+atomic = "0.6.0"
+bstr = "1.8.0"
 byte-unit = "5.0.3"
 clap = { version = "4.4.6", default-features = false, features = ["derive", "std"] }
 eframe = "0.24.1"
@@ -18,6 +19,7 @@ egui_plot = "0.24.1"
 hdrhistogram = { version = "7.5.2", default-features = false }
 indexmap = "2.0.0"
 livesplit-auto-splitting = { git = "https://github.com/LiveSplit/livesplit-core" }
+mime_guess = "2.0.4"
 
 [profile.max-opt]
 inherits = "release"

--- a/src/file_filter.rs
+++ b/src/file_filter.rs
@@ -1,0 +1,115 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use bstr::ByteSlice;
+use livesplit_auto_splitting::settings::FileFilter;
+
+pub fn build(filters: Arc<Vec<FileFilter>>) -> egui_file::Filter<PathBuf> {
+    Box::new(move |p: &Path| {
+        let name = p.file_name().unwrap_or_default().as_encoded_bytes();
+        filters.iter().any(|filter| matches_filter(name, filter))
+    })
+}
+
+fn matches_filter(file_name: &[u8], filter: &FileFilter) -> bool {
+    match filter {
+        FileFilter::Name {
+            description: _,
+            pattern,
+        } => pattern
+            .split(' ')
+            .any(|pattern| matches_single_pattern(file_name, pattern.as_bytes())),
+        FileFilter::MimeType(mime_type) => matches_mime_type(file_name, mime_type),
+    }
+}
+
+fn matches_single_pattern(mut file_name: &[u8], mut pattern: &[u8]) -> bool {
+    let mut strip_any = false;
+    while !pattern.is_empty() {
+        strip_any = if let [b'*', rem @ ..] = pattern {
+            pattern = rem;
+            true
+        } else {
+            let (fixed, rem) = pattern.split_at(
+                pattern
+                    .iter()
+                    .position(|&b| b == b'*')
+                    .unwrap_or(pattern.len()),
+            );
+            pattern = rem;
+            file_name = if strip_any {
+                let Some((_, rem)) = file_name.split_once_str(fixed) else {
+                    return false;
+                };
+                rem
+            } else {
+                let Some(rem) = file_name.strip_prefix(fixed.as_bytes()) else {
+                    return false;
+                };
+                rem
+            };
+            false
+        };
+    }
+    strip_any || file_name.is_empty()
+}
+
+fn matches_mime_type(file_name: &[u8], mime_type: &str) -> bool {
+    let Some((top, sub)) = mime_type.split_once('/') else {
+        return false;
+    };
+    let Some(extensions) = mime_guess::get_extensions(top, sub) else {
+        return false;
+    };
+    let Some((_, extension)) = file_name.rsplit_once_str(&[b'.']) else {
+        return false;
+    };
+    extensions.iter().any(|ext| extension == ext.as_bytes())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_matches_single_pattern() {
+        assert!(matches_single_pattern(b"bar.exe", b"*.exe"));
+        assert!(!matches_single_pattern(b"bar.exeafter", b"*.exe"));
+        assert!(!matches_single_pattern(b"beforebar.exe", b"bar*"));
+        assert!(matches_single_pattern(b"beforebarafter", b"*bar*"));
+        assert!(matches_single_pattern(b"bar.txt", b"*.txt"));
+        assert!(matches_single_pattern(b"quick brown fox", b"*ick*row*ox"));
+        assert!(matches_single_pattern(b"quick brown fox", b"q*ick*row*ox"));
+        assert!(!matches_single_pattern(b"quick brown fox", b"*row*ox*ick*"));
+    }
+
+    #[test]
+    fn test_matches_mime_type() {
+        assert!(matches_mime_type(b"foo.txt", "text/plain"));
+        assert!(matches_mime_type(b"foo.jpg", "image/jpeg"));
+        assert!(matches_mime_type(b"foo.jpeg", "image/jpeg"));
+        assert!(matches_mime_type(b"foo.png", "image/png"));
+
+        assert!(!matches_mime_type(b"foo.txt", "image/*"));
+        assert!(matches_mime_type(b"foo.jpg", "image/*"));
+        assert!(matches_mime_type(b"foo.jpeg", "image/*"));
+        assert!(matches_mime_type(b"foo.png", "image/*"));
+
+        assert!(!matches_mime_type(b"txt", "text/plain"));
+        assert!(!matches_mime_type(b"jpg", "image/jpeg"));
+        assert!(!matches_mime_type(b"jpeg", "image/jpeg"));
+        assert!(!matches_mime_type(b"png", "image/png"));
+
+        assert!(!matches_mime_type(b"footxt", "text/plain"));
+        assert!(!matches_mime_type(b"foojpg", "image/jpeg"));
+        assert!(!matches_mime_type(b"foojpeg", "image/jpeg"));
+        assert!(!matches_mime_type(b"foopng", "image/png"));
+
+        assert!(!matches_mime_type(b"foo.txt", "image/jpeg"));
+        assert!(!matches_mime_type(b"foo.jpg", "image/png"));
+        assert!(!matches_mime_type(b"foo.jpeg", "image/png"));
+        assert!(!matches_mime_type(b"foo.png", "text/plain"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1155,6 +1155,17 @@ fn parse_filter(filter: &str) -> egui_file::Filter {
         let name = p.file_name().unwrap_or_default().to_string_lossy();
         variants
             .iter()
-            .any(|pieces| pieces.iter().all(|piece| name.contains(piece)))
+            .any(|pieces| contains_all_in_order(&name, &pieces))
     })
+}
+
+fn contains_all_in_order(haystack: &str, needles: &[String]) -> bool {
+    let mut hay: &str = haystack;
+    for piece in needles {
+        let Some((_, rst)) = hay.split_once(piece) else {
+            return false;
+        };
+        hay = rst;
+    }
+    true
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1169,3 +1169,65 @@ fn contains_all_in_order(haystack: &str, needles: &[String]) -> bool {
     }
     true
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_contains_all_in_order() {
+        assert!(contains_all_in_order("bar.exe", &[".exe".to_string()]));
+        assert!(contains_all_in_order(
+            "bar.exe",
+            &["".to_string(), ".exe".to_string()]
+        ));
+        assert!(contains_all_in_order(
+            "bar.txt",
+            &["".to_string(), ".txt".to_string()]
+        ));
+        assert!(!contains_all_in_order(
+            "bar.txt",
+            &["".to_string(), ".exe".to_string()]
+        ));
+        assert!(!contains_all_in_order(
+            "bar.exe",
+            &["".to_string(), ".txt".to_string()]
+        ));
+        assert!(contains_all_in_order(
+            "quick brown fox",
+            &["ick".to_string(), "row".to_string(), "ox".to_string()]
+        ));
+        assert!(!contains_all_in_order(
+            "quick brown fox",
+            &["row".to_string(), "ox".to_string(), "ick".to_string()]
+        ));
+    }
+
+    #[test]
+    fn single_pattern_filter() {
+        let filter_exe = parse_filter("*.exe");
+        let filter_txt = parse_filter("*.txt");
+        assert!(filter_exe(Path::new(r"/foo/bar.exe")));
+        assert!(filter_txt(Path::new(r"/mnt/foo/bar.txt")));
+        assert!(filter_exe(Path::new(r"/mnt/c/foo/bar.exe")));
+        assert!(filter_txt(Path::new(r"C:\foo\bar.txt")));
+        assert!(!filter_exe(Path::new(r"/foo/bar.txt")));
+        assert!(!filter_txt(Path::new(r"/mnt/foo/bar.exe")));
+        let filter_bar_exe = parse_filter("*bar*.exe");
+        assert!(filter_bar_exe(Path::new(r"/foo/bar.exe")));
+        assert!(!filter_bar_exe(Path::new(r"/foo/bar/baz.exe")));
+        assert!(!filter_bar_exe(Path::new(r"/foo/baz.exe.bar.txt")));
+    }
+
+    #[test]
+    fn multi_pattern_filter() {
+        let filter_txt_md = parse_filter("*.txt;*md");
+        assert!(filter_txt_md(Path::new(r"/foo/bar.txt")));
+        assert!(filter_txt_md(Path::new(r"/mnt/foo/bar.md")));
+        assert!(filter_txt_md(Path::new(r"/mnt/c/foo/bar.txt")));
+        assert!(filter_txt_md(Path::new(r"C:\foo\bar.md")));
+        assert!(!filter_txt_md(Path::new(r"/foo/bar.exe")));
+        assert!(!filter_txt_md(Path::new(r"/foo/bar.txt/baz.exe")));
+        assert!(!filter_txt_md(Path::new(r"/foo/bar.md/baz.exe")));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::{
     fmt,
     fs::{self, File},
     io::Write,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, AtomicUsize},
         Arc, Mutex, RwLock,
@@ -31,8 +31,9 @@ use egui_plot::{Bar, BarChart, Legend, Plot, VLine};
 use hdrhistogram::Histogram;
 use indexmap::IndexMap;
 use livesplit_auto_splitting::{
-    settings, time, AutoSplitter, CompiledAutoSplitter, Config, ExecutionGuard, Runtime, Timer,
-    TimerState,
+    settings, time,
+    wasi_path::{path_to_wasi, wasi_to_path},
+    AutoSplitter, CompiledAutoSplitter, Config, ExecutionGuard, Runtime, Timer, TimerState,
 };
 
 mod clear_vec;
@@ -278,11 +279,17 @@ struct AppState {
     module_modified_time: Option<SystemTime>,
     script_modified_time: Option<SystemTime>,
     optimize: bool,
-    open_file_dialog: Option<(FileDialog, bool)>,
+    open_file_dialog: Option<(FileDialog, FileDialogInfo)>,
     module: Option<CompiledAutoSplitter>,
     shared_state: Arc<SharedState>,
     timer: DebuggerTimer,
     runtime: livesplit_auto_splitting::Runtime,
+}
+
+enum FileDialogInfo {
+    WASM,
+    Script,
+    SettingsWidget(Arc<str>),
 }
 
 struct TabViewer<'a> {
@@ -309,7 +316,7 @@ impl egui_dock::TabViewer for TabViewer<'_> {
                             if ui.button("Open").clicked() {
                                 let mut dialog = FileDialog::open_file(self.state.path.clone());
                                 dialog.open();
-                                self.state.open_file_dialog = Some((dialog, true));
+                                self.state.open_file_dialog = Some((dialog, FileDialogInfo::WASM));
                             }
                             if let Some(auto_splitter) = &*self.state.shared_state.auto_splitter.load() {
                                     if ui.button("Restart").clicked() {
@@ -330,7 +337,7 @@ impl egui_dock::TabViewer for TabViewer<'_> {
                                 let mut dialog =
                                     FileDialog::open_file(self.state.script_path.clone());
                                 dialog.open();
-                                self.state.open_file_dialog = Some((dialog, false));
+                                self.state.open_file_dialog = Some((dialog, FileDialogInfo::Script));
                             }
                             if self.state.shared_state.auto_splitter.load().is_some() {
                                 if let Some(script_path) = &self.state.script_path {
@@ -607,6 +614,30 @@ impl egui_dock::TabViewer for TabViewer<'_> {
                                     }
                                 }
                             }
+                            settings::WidgetKind::FileSelection { ref filter } => {
+                                ui.add_space(spacing);
+                                let settings_map = runtime.settings_map();
+                                let current_path: Option<PathBuf> =
+                                    match settings_map.get(&setting.key) {
+                                        Some(settings::Value::String(path)) => wasi_to_path(path),
+                                        _ => None,
+                                    };
+                                let filter_pieces: Vec<String> =
+                                    filter.split('*').map(String::from).collect();
+                                if ui.button(&*setting.description).clicked() {
+                                    let mut dialog = FileDialog::open_file(current_path).filter(
+                                        Box::new(move |p: &Path| {
+                                            let s = p.to_string_lossy();
+                                            filter_pieces.iter().all(|f| s.contains(f))
+                                        }),
+                                    );
+                                    dialog.open();
+                                    self.state.open_file_dialog = Some((
+                                        dialog,
+                                        FileDialogInfo::SettingsWidget(setting.key.clone()),
+                                    ));
+                                }
+                            }
                         });
                         ui.end_row();
                     }
@@ -800,13 +831,31 @@ impl App for Debugger {
             }
         }
 
-        if let Some((dialog, is_wasm)) = &mut self.state.open_file_dialog {
+        if let Some((dialog, info)) = &mut self.state.open_file_dialog {
             if dialog.show(ctx).selected() {
                 if let Some(file) = dialog.path().map(ToOwned::to_owned) {
-                    if *is_wasm {
-                        self.state.load(Load::File(file));
-                    } else {
-                        self.state.set_script_path(file);
+                    match info {
+                        FileDialogInfo::WASM => self.state.load(Load::File(file)),
+                        FileDialogInfo::Script => self.state.set_script_path(file),
+                        FileDialogInfo::SettingsWidget(key) => {
+                            if let Some(s) = path_to_wasi(&file) {
+                                if let Some(runtime) =
+                                    &*self.state.shared_state.runtime.read().unwrap()
+                                {
+                                    loop {
+                                        let old = runtime.settings_map();
+                                        let mut new = old.clone();
+                                        new.insert(
+                                            key.clone(),
+                                            settings::Value::String(s.as_ref().into()),
+                                        );
+                                        if runtime.set_settings_map_if_unchanged(&old, new) {
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
A companion PR to https://github.com/LiveSplit/livesplit-core/pull/748.

Implements the FileSelection Widget as a button in the settings Gui that opens a file dialog when pressed. The user can select a file, and the WASI-compatible path to that file gets stored in the settings map.

This code won't fully work until after the `livesplit-core` dependency has been updated, but to help with testing I have this branch to point the dependency at my `livesplit-core` PR branch: https://github.com/AlexKnauth/asr-debugger/commits/file-selection-demo